### PR TITLE
Upgrade h3spec to v0.1.8

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -68,7 +68,7 @@
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
         <netty.build.version>29</netty.build.version>
-        <h3spec.version>v0.1.7</h3spec.version>
+        <h3spec.version>v0.1.8</h3spec.version>
         <h3spec.url>https://github.com/kazu-yamamoto/h3spec/releases/download</h3spec.url>
         <h3spec.linux.name>h3spec-linux-x86_64</h3spec.linux.name>
         <h3spec.mac.name>h3spec-mac-x86_64</h3spec.mac.name>

--- a/src/main/java/io/netty/incubating/maven/h3spec/H3SpecMojo.java
+++ b/src/main/java/io/netty/incubating/maven/h3spec/H3SpecMojo.java
@@ -78,15 +78,26 @@ public class H3SpecMojo extends AbstractMojo {
     private boolean skip;
 
     /**
-     * Allow to skip execution of plugin
+     * Delay to allow server to startup before we run this test
      */
     @Parameter(property = "delay", defaultValue = "1000", required = true)
     private long delay;
 
+    /**
+     * Timeout in milliseconds for each test.
+     */
+    @Parameter(property = "timeoutMillis", defaultValue = "1000")
+    private long timeoutMillis;
+
+    /**
+     * Timeout in milliseconds for each test.
+     */
+    @Parameter(property = "debug", defaultValue = "false")
+    private boolean debug;
+
     @Component
     private MavenProject project;
 
-    @SuppressWarnings("unchecked")
     private ClassLoader getClassLoader() throws MojoExecutionException {
         try {
             List<String> classpathElements = project.getTestClasspathElements();
@@ -159,8 +170,8 @@ public class H3SpecMojo extends AbstractMojo {
                 }
 
                 File outputDirectory = new File(project.getBuild().getDirectory());
-                H3SpecResult result = H3Spec.execute(outputDirectory,
-                        port, new HashSet<>(excludeSpecs));
+                H3Spec.Config config = new H3Spec.Config(host, port, excludeSpecs, timeoutMillis, debug);
+                H3SpecResult result = H3Spec.execute(outputDirectory, config);
 
                 File reportsDirectory = new File(outputDirectory, "h3spec-reports");
                 if (!reportsDirectory.exists()) {


### PR DESCRIPTION
__Motivation__

h3spec now has a new version and it supports configuring timeout for tests. We should support the same with the maven plugin

__Modification__

- Added support for properties `debug` and `timeoutMillis`

__Result__

h3spec latest version is used and we support timeouts for tests.